### PR TITLE
Serve static files and html

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,21 @@
+import os
+from flask import Flask, send_from_directory
+
+app = Flask(__name__, static_folder='../static')
+
+FRONTEND_DIR = os.path.join(os.path.dirname(__file__), '..', 'frontend')
+
+@app.route('/')
+def index():
+    return send_from_directory(FRONTEND_DIR, 'index.html')
+
+@app.route('/builder')
+def builder():
+    return send_from_directory(FRONTEND_DIR, 'builder.html')
+
+@app.route('/view-form')
+def view_form():
+    return send_from_directory(FRONTEND_DIR, 'view-form.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/frontend/builder.html
+++ b/frontend/builder.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Form Builder</title>
+    <link rel="stylesheet" type="text/css" href="/static/css/style.css">
+</head>
+<body>
+    <h1>Form Builder</h1>
+    <a href="/">Home</a>
+    <script src="/static/js/app.js"></script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Form Home</title>
+    <link rel="stylesheet" type="text/css" href="/static/css/style.css">
+</head>
+<body>
+    <h1>Welcome to the Form App</h1>
+    <a href="/builder">Create a new form</a>
+    <script src="/static/js/app.js"></script>
+</body>
+</html>

--- a/frontend/view-form.html
+++ b/frontend/view-form.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>View Form</title>
+    <link rel="stylesheet" type="text/css" href="/static/css/style.css">
+</head>
+<body>
+    <h1>View Form</h1>
+    <a href="/">Home</a>
+    <script src="/static/js/app.js"></script>
+</body>
+</html>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,1 @@
+body { font-family: Arial; }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,1 @@
+console.log("app initialized");


### PR DESCRIPTION
## Summary
- add Flask backend serving HTML from frontend directory
- serve static assets from `../static`
- add simple frontend pages with links that match new routes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862ce45d1188324a83517244d1ef1b5